### PR TITLE
Fix bugsnag upgrade issue comptability

### DIFF
--- a/lib/bugsnag-capistrano/release.rb
+++ b/lib/bugsnag-capistrano/release.rb
@@ -11,15 +11,6 @@ module Bugsnag
       DEFAULT_BUILD_TOOL_NAME = "bugsnag-capistrano"
 
       def self.notify(opts = {})
-        # Try and get some config from Bugsnag
-        begin
-          require 'bugsnag'
-
-          opts[:api_key] ||= Bugsnag.configuration.api_key
-          opts[:app_version] ||= Bugsnag.configuration.app_version
-          opts[:release_stage] ||= Bugsnag.configuration.release_stage
-        rescue LoadError
-        end
 
         opts[:endpoint] ||= DEFAULT_BUILD_ENDPOINT
         opts[:builder_name] ||= `whoami`


### PR DESCRIPTION
Resolving issue of: ```Bugsnag release notification failed, #<NoMethodError: undefined method `event_subscription' for Bugsnag::Railtie:Class>``` When we upgraded Bugsnag to 6.13.0